### PR TITLE
correct message status handling

### DIFF
--- a/test/unit/watch.js
+++ b/test/unit/watch.js
@@ -138,7 +138,7 @@ serial-screen-off-cmd=`);
   it("should clear settings if local file is not current", done => {
     watch.receiveConfigurationFile({
       topic: "file-update",
-      status: "UNKNOWN",
+      status: "DELETED",
       ospath: "xxxxxxx/screen-control.txt"
     })
     .then(() => {


### PR DESCRIPTION
Corrected file status conditional that Tyler noticed could be improved after merging. Please review. Now we consider not configured only if status of file is 'DELETED' or 'NOEXIST'.