### PR TITLE
Use cec-monitor fork without deasync dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@senzil/cec-monitor": {
-      "version": "2.0.0-release.79",
-      "resolved": "https://registry.npmjs.org/@senzil/cec-monitor/-/cec-monitor-2.0.0-release.79.tgz",
-      "integrity": "sha512-z7CLTHtW+vwa/56Mz2LRU0Izeueq50Ap7i8DGc/CSXDF9dGVJ4RW4SxGw7nzJfpS1wNd4FMu70z4D0oOzwLYpw==",
-      "requires": {
-        "deasync-promise": "1.0.1",
-        "death": "1.1.0",
-        "event-stream": "3.3.4"
-      }
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -649,11 +639,6 @@
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
     "bl": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
@@ -1230,23 +1215,6 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
-    },
-    "deasync": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.11.tgz",
-      "integrity": "sha1-PR8iii/s9KGzWdouY2iJlC+L8Uw=",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.8.0"
-      }
-    },
-    "deasync-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deasync-promise/-/deasync-promise-1.0.1.tgz",
-      "integrity": "sha1-KyfeR4Fnr07zS6mYecUuwM7dYcI=",
-      "requires": {
-        "deasync": "0.1.11"
-      }
     },
     "death": {
       "version": "1.1.0",
@@ -3344,11 +3312,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4245,6 +4208,13 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
+      }
+    },
+    "rise-cec-monitor": {
+      "version": "git://github.com/Rise-Vision/rise-cec-monitor.git#94631d9c4a16aeb280f62d11d54a455858c4ace3",
+      "requires": {
+        "death": "1.1.0",
+        "event-stream": "3.3.4"
       }
     },
     "rise-common-electron": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "zip-webpack-plugin": "^2.0.0"
   },
   "dependencies": {
-    "@senzil/cec-monitor": "^2.0.0-release.79",
+    "rise-cec-monitor": "git://github.com/Rise-Vision/rise-cec-monitor.git#94631d9",
     "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#v1.5.5",
     "node-ipc": "^9.1.1",
     "rise-common-electron": "git://github.com/Rise-Vision/rise-common-electron.git#v2.2.3"

--- a/src/strategies/cec/index.js
+++ b/src/strategies/cec/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 const child = require("child_process");
 
-const CECMonitor = require("@senzil/cec-monitor").CECMonitor;
+const CECMonitor = require("rise-cec-monitor").CECMonitor;
 const CECControlStrategy = require("./strategy");
 
 let strategy = null;

--- a/test/manual/cec/connect.js
+++ b/test/manual/cec/connect.js
@@ -3,7 +3,7 @@
 // test if we have connection to the CEC adapter.
 // unless this test finishes successfully, the other tests in this same folder won't work.
 
-const CECMonitor = require("@senzil/cec-monitor").CECMonitor;
+const CECMonitor = require("rise-cec-monitor").CECMonitor;
 const SECONDS = 5;
 
 const monitor = new CECMonitor('RV', {

--- a/test/manual/cec/send_command.js
+++ b/test/manual/cec/send_command.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 
-const CECMonitor = require("@senzil/cec-monitor").CECMonitor;
+const CECMonitor = require("rise-cec-monitor").CECMonitor;
 const SECONDS = 10;
 
 module.exports = command =>


### PR DESCRIPTION
The deasync dependency is problematic in Electron.