### PR TITLE
Fix/filter config updates

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -53,7 +53,7 @@ function loadCurrentConfiguration(configurationPath) {
     {
       const settings = parser.parseContent(data);
 
-      logger.debug(`loading settings ${JSON.stringify(settings)}`);
+      logger.file(`loading settings ${JSON.stringify(settings)}`);
 
       config.setDisplayControlSettings(settings);
     })
@@ -67,6 +67,8 @@ function loadCurrentConfiguration(configurationPath) {
 }
 
 function receiveConfigurationFile(message) {
+  logger.file(`***** ${message.status}`);
+
   switch (message.status) {
     case "DELETED": case "NOEXIST":
       // if we don't have a file set empty configuration.

--- a/src/watch.js
+++ b/src/watch.js
@@ -45,7 +45,7 @@ function sendWatchMessages() {
 }
 
 function loadCurrentConfiguration(configurationPath) {
-  if (configurationPath) {
+  if (configurationPath && platform.fileExists(configurationPath)) {
     logger.debug(`reading ${configurationPath}`);
 
     return platform.readTextFile(configurationPath)
@@ -67,8 +67,6 @@ function loadCurrentConfiguration(configurationPath) {
 }
 
 function receiveConfigurationFile(message) {
-  logger.file(`***** ${message.status}`);
-
   switch (message.status) {
     case "DELETED": case "NOEXIST":
       // if we don't have a file set empty configuration.

--- a/test/unit/watch.js
+++ b/test/unit/watch.js
@@ -17,6 +17,7 @@ describe("Watch - Unit", ()=> {
     simple.mock(common, "broadcastMessage").returnWith();
     simple.mock(logger, "error").returnWith();
     simple.mock(common, "getDisplaySettings").resolveWith(settings);
+    simple.mock(platform, "fileExists").returnWith(true);
   });
 
   afterEach(()=> {


### PR DESCRIPTION
When display-control-module starts, the configuration file is not initially present, so local-storage-module sends a STALE message indicating it is going to be downloaded. display-control-module tries to read the still non-existent file and fails, logging an error message. Later, the file may be downloaded or detected to be nonexistent, and it continues working normally, but this misleading error message may be part of its initial run.

This issue was first reported during the test week for beta rollout, but wasn't finished then. To avoid the unwanted error message I'm checking for configuration file existence before attempting to read it.