### PR TITLE
request licensing data if display control is configured but licensing…

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -103,6 +103,10 @@ function isAuthorized() {
   return authorized;
 }
 
+function hasReceivedAuthorization() {
+  return authorized !== null;
+}
+
 // Clear all state, for testing purposes only
 function clear() {
   setDisplayControlSettings(null);
@@ -130,5 +134,6 @@ module.exports = {
   checkTimelineNow,
   setAuthorized,
   isAuthorized,
+  hasReceivedAuthorization,
   clear
 };

--- a/src/interval-schedule-check.js
+++ b/src/interval-schedule-check.js
@@ -1,8 +1,9 @@
 const config = require("./config");
-const logger = require("./logger.js");
-const scheduleCheckInterval = 60000;
-const screen = require("./screen.js");
+const licensing = require("./licensing");
+const logger = require("./logger");
+const screen = require("./screen");
 
+const scheduleCheckInterval = 60000;
 let lastCommand = null;
 
 module.exports = {
@@ -12,12 +13,24 @@ module.exports = {
   runCheck
 };
 
+function ensureLicenseHasBeenRequested() {
+  if (config.hasValidStrategy()) {
+    logger.logNotAuthorizedWithValidStrategy();
+
+    if (!config.hasReceivedAuthorization()) {
+      return licensing.requestLicensingData();
+    }
+  }
+
+  return Promise.resolve();
+}
+
 function runCheck(date = null) {
   try {
     logger.debug("running display control check");
 
     if (!config.isDisplayControlEnabled()) {
-      return logger.logNotAuthorizedIfHasValidStrategy();
+      return ensureLicenseHasBeenRequested();
     }
 
     logger.clearLoggedNotAuthorizedFlag();

--- a/src/licensing.js
+++ b/src/licensing.js
@@ -6,6 +6,8 @@ const logger = require("./logger");
 let initialRequestAlreadySent = false;
 
 function requestLicensingData() {
+  logger.file('requesting licensing data');
+
   return licensing.requestLicensingData(config.moduleName)
   .catch(error => {
     logger.error(error.stack, 'Error while requesting licensing data');

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,7 +1,7 @@
 /* eslint-disable space-in-parens */
 const common = require("common-display-module");
 const {
-  bqProjectName, bqDataset, bqTable, failedEntryFile, hasValidStrategy,
+  bqProjectName, bqDataset, bqTable, failedEntryFile,
   logFolder, moduleName, getModuleVersion
 } = require("./config");
 
@@ -62,14 +62,12 @@ function logResult(result) {
   )
 }
 
-function logNotAuthorizedIfHasValidStrategy() {
-  if (!alreadyLoggedNotAuthorized && hasValidStrategy()) {
+function logNotAuthorizedWithValidStrategy() {
+  if (!alreadyLoggedNotAuthorized) {
     module.exports.all("not_authorized", "Display control is not authorized to run even though it has a valid strategy configured.");
 
     alreadyLoggedNotAuthorized = true;
   }
-
-  return Promise.resolve();
 }
 
 function clearLoggedNotAuthorizedFlag() {
@@ -83,7 +81,7 @@ module.exports = {
   external,
   all,
   clearLoggedNotAuthorizedFlag,
-  logNotAuthorizedIfHasValidStrategy,
+  logNotAuthorizedWithValidStrategy,
   logResult,
   sendCommandAttempt,
   sendCommandFailure

--- a/test/unit/interval-schedule-check.js
+++ b/test/unit/interval-schedule-check.js
@@ -4,6 +4,8 @@
 const assert = require("assert");
 const simple = require("simple-mock");
 const config = require("../../src/config");
+const licensing = require("../../src/licensing");
+const logger = require("../../src/logger");
 const screen = require("../../src/screen");
 const interval = require("../../src/interval-schedule-check");
 
@@ -12,6 +14,8 @@ describe("Interval Schedule Check - Unit", ()=>{
     simple.mock(config, "isDisplayControlEnabled").returnWith(true);
     simple.mock(screen, "turnOn").resolveWith();
     simple.mock(screen, "turnOff").resolveWith();
+    simple.mock(licensing, "requestLicensingData").resolveWith();
+    simple.mock(logger, "logNotAuthorizedWithValidStrategy").returnWith();
   });
 
   afterEach(()=>{
@@ -21,9 +25,36 @@ describe("Interval Schedule Check - Unit", ()=>{
   it("should not send any command if display control is not enabled", ()=>{
     simple.mock(config, "isDisplayControlEnabled").returnWith(false);
     simple.mock(config, "checkTimelineNow").returnWith(true);
+    simple.mock(config, "hasValidStrategy").returnWith(false);
 
     return interval.runCheck()
     .then(() => assert(!screen.turnOn.called));
+  });
+
+  it("should log not authorized if display control is not enabled but has valid strategy", ()=>{
+    simple.mock(config, "isDisplayControlEnabled").returnWith(false);
+    simple.mock(config, "checkTimelineNow").returnWith(true);
+    simple.mock(config, "hasValidStrategy").returnWith(true);
+    simple.mock(config, "hasReceivedAuthorization").returnWith(true);
+
+    return interval.runCheck()
+    .then(() => {
+      assert(!screen.turnOn.called);
+      assert(!licensing.requestLicensingData.called);
+    });
+  });
+
+  it("should log not authorized and request licensing data if display control is not enabled but has valid strategy and no authorization has been received", ()=>{
+    simple.mock(config, "isDisplayControlEnabled").returnWith(false);
+    simple.mock(config, "checkTimelineNow").returnWith(true);
+    simple.mock(config, "hasValidStrategy").returnWith(true);
+    simple.mock(config, "hasReceivedAuthorization").returnWith(false);
+
+    return interval.runCheck()
+    .then(() => {
+      assert(!screen.turnOn.called);
+      assert.equal(licensing.requestLicensingData.callCount, 1);
+    });
   });
 
   it("should turn the screen on if timeline is now valid for play", ()=>{


### PR DESCRIPTION
There seems to be a race condition with licensing data requests. Even if I wait until licensing module is available to request licensing data, the logs in licensing module show no licensing requests. Maybe it's because the request is performed after licensing registers with local-messaging, but before it has configured its own message handler.

The workaround here is to request licensing data ( again ) whenever we see there is a valid display control configuration and suitable schedule, but we haven't received licensing data yet.
