### PR TITLE
Handle STALE content.json message 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,13 @@ const displayConfigBucket = "risevision-display-notifications";
 const logger = require("./logger");
 
 process.on("uncaughtException", (err)=>{
-  logger.file(err.stack);
-  process.exit(); // eslint-disable-line no-process-exit
+  logger.error(err.stack, 'Uncaught exception');
+  process.exit(1); // eslint-disable-line no-process-exit
 });
 
 process.on("unhandledRejection", (reason)=>{
-  logger.file(reason.stack || reason);
-  process.exit(); // eslint-disable-line no-process-exit
+  logger.error(reason.stack || reason, 'Unhandled rejection');
+  process.exit(1); // eslint-disable-line no-process-exit
 });
 
 process.on("SIGPIPE", () => logger.external("SIGPIPE received"));

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,16 @@ const displayConfigBucket = "risevision-display-notifications";
 const logger = require("./logger");
 
 process.on("uncaughtException", (err)=>{
+  logger.debug("uncaughtException", err);
   logger.error(err.stack, 'Uncaught exception');
+  // eslint-disable-next-line no-magic-numbers
   process.exit(1); // eslint-disable-line no-process-exit
 });
 
 process.on("unhandledRejection", (reason)=>{
+  logger.debug("unhandledRejection", reason);
   logger.error(reason.stack || reason, 'Unhandled rejection');
+  // eslint-disable-next-line no-magic-numbers
   process.exit(1); // eslint-disable-line no-process-exit
 });
 

--- a/src/watch.js
+++ b/src/watch.js
@@ -92,7 +92,7 @@ function receiveConfigurationFile(message) {
 function receiveContentFile(message) {
   logger.file(JSON.stringify(message), "receiving content file message");
 
-  if (["DELETED", "NOEXIST"].includes(message.status)) {return;}
+  if (["DELETED", "NOEXIST", "STALE"].includes(message.status)) {return Promise.resolve();}
 
   return platform.readTextFile(message.ospath)
   .then(fileData=>{

--- a/test/unit/watch.js
+++ b/test/unit/watch.js
@@ -154,7 +154,7 @@ serial-screen-off-cmd=`);
     });
   });
 
-  it("should catch invalid content file", () => {
+  it("should catch incomplete content file", () => {
     const mockScheduleText = '{{';
     simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
 
@@ -167,4 +167,53 @@ serial-screen-off-cmd=`);
       assert(logger.error.lastCall.args[1].startsWith("Could not parse"));
     });
   });
+
+  it("should skip DELETED content file message", () => {
+    const mockScheduleText = '{"content": {"schedule": {"timeDefined": true}}}';
+    simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
+    simple.mock(config, "setTimeline").returnWith();
+
+    return watch.receiveContentFile({
+      topic: "file-update",
+      status: "DELETED",
+      ospath: "xxxxxxx"
+    })
+    .then(() => {
+      assert.equal(config.setTimeline.called, false);
+      assert.equal(platform.readTextFile.called, false);
+    });
+  });
+
+  it("should skip NOEXIST content file message", () => {
+    const mockScheduleText = '{"content": {"schedule": {"timeDefined": true}}}';
+    simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
+    simple.mock(config, "setTimeline").returnWith();
+
+    return watch.receiveContentFile({
+      topic: "file-update",
+      status: "NOEXIST",
+      ospath: "xxxxxxx"
+    })
+    .then(() => {
+      assert.equal(config.setTimeline.called, false);
+      assert.equal(platform.readTextFile.called, false);
+    });
+  });
+
+  it("should skip STALE content file message", () => {
+    const mockScheduleText = '{"content": {"schedule": {"timeDefined": true}}}';
+    simple.mock(platform, "readTextFile").resolveWith(mockScheduleText);
+    simple.mock(config, "setTimeline").returnWith();
+
+    return watch.receiveContentFile({
+      topic: "file-update",
+      status: "STALE",
+      ospath: "xxxxxxx"
+    })
+    .then(() => {
+      assert.equal(config.setTimeline.called, false);
+      assert.equal(platform.readTextFile.called, false);
+    });
+  });
+
 });


### PR DESCRIPTION
## Description
- Ignore messages from local-storage on content.json when status is "STALE"
- Improve logs

## Motivation and Context
The module was crashing when the STALE message arrived but there was no content.json file in the file system. This was causing defect https://github.com/Rise-Vision/rise-launcher-electron/issues/834

## How Has This Been Tested?
Tested on Uptime machine with staged version

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
